### PR TITLE
Avoid PHP notice on empty integer fields

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -134,7 +134,7 @@ function escape_pointer($pointer)
  */
 function is_json_integer($value)
 {
-    if (is_string($value) && $value[0] === '-') {
+    if (is_string($value) && strlen($value) && $value[0] === '-') {
         $value = substr($value, 1);
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -12,7 +12,8 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             [99, true],
             ["hello-world", false],
             ["99", false],
-            ["-99", false]
+            ["-99", false],
+            ["", false]
         ];
     }
 


### PR DESCRIPTION
Avoid "PHP Notice: Uninitialized string offset: 0" when an integer
fields contains an empty string instead of an integer.