### PR TITLE
Property with name `$ref` should not be considered a reference. Fixes #37.

### DIFF
--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -165,7 +165,7 @@ class Dereferencer
         $refs = [];
 
         if (!is_array($schema) && !is_object($schema)) {
-            if ($this->isRef($schema)) {
+            if ($this->isRef($path, $schema)) {
                 $refs[$path] = $schema;
             }
 
@@ -173,7 +173,7 @@ class Dereferencer
         }
 
         foreach ($schema as $attribute => $parameter) {
-            if ($this->isRef($attribute)) {
+            if ($this->isRef($attribute, $parameter)) {
                 $refs[$path] = $parameter;
             }
             if (is_object($parameter)) {
@@ -207,12 +207,13 @@ class Dereferencer
 
     /**
      * @param string $attribute
+     * @param mixed $attribute_value
      *
      * @return bool
      */
-    private function isRef($attribute)
+    private function isRef($attribute, $attribute_value)
     {
-        return $attribute === '$ref';
+        return $attribute === '$ref' && is_string($attribute_value);
     }
 
     /**

--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -207,13 +207,13 @@ class Dereferencer
 
     /**
      * @param string $attribute
-     * @param mixed $attribute_value
+     * @param mixed $attributeValue
      *
      * @return bool
      */
-    private function isRef($attribute, $attribute_value)
+    private function isRef($attribute, $attributeValue)
     {
-        return $attribute === '$ref' && is_string($attribute_value);
+        return $attribute === '$ref' && is_string($attributeValue);
     }
 
     /**

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -94,4 +94,15 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $tildeProperty = 'tilde~item';
         $this->assertSame($result->$tildeProperty->key, $result->item->key);
     }
+
+    public function testPropertyNamedRefIsNotAReference()
+    {
+        $deref  = new Dereferencer();
+        $path   = 'file://' . __DIR__ . '/fixtures/property-named-ref.json';
+        $result = $deref->dereference($path);
+
+        $ref = '$ref';
+        $this->assertTrue(is_object($result->properties->$ref));
+        $this->assertSame($result->properties->$ref->description, 'The name of the property is $ref, but it\'s not a reference.');
+    }
 }

--- a/tests/fixtures/property-named-ref.json
+++ b/tests/fixtures/property-named-ref.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "$ref": {
+            "description": "The name of the property is $ref, but it's not a reference.",
+            "type": "string"
+        },
+        "name": {
+            "description": "Just another property.",
+            "type": "string"
+        }
+    },
+    "required": ["$ref", "name"]
+}


### PR DESCRIPTION
Fixes #37 . Now the value of the attribute must be a string to be considered an reference (`$ref`).