### PR TITLE
Remove unreachable block

### DIFF
--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -165,10 +165,6 @@ class Dereferencer
         $refs = [];
 
         if (!is_array($schema) && !is_object($schema)) {
-            if ($this->isRef($path, $schema)) {
-                $refs[$path] = $schema;
-            }
-
             return $refs;
         }
 


### PR DESCRIPTION
Since the method only takes objects, we don't need to check if it's a reference.  This code is never executed by the test suite.