### PR TITLE
Improve dereferencing resolution scopes

### DIFF
--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -36,15 +36,15 @@ class Dereferencer
      */
     public function dereference($schema)
     {
-        $uri = is_string($schema) ? $schema : null;
-
-        if ($uri) {
+        if (is_string($schema)) {
+            $uri    =  $schema;
             $schema = $this->loadExternalRef($uri);
             $schema = $this->resolveFragment($uri, $schema);
-            $uri    = strip_fragment($uri);
+
+            return $this->crawl($schema, strip_fragment($uri));
         }
 
-        return $this->crawl($schema, $uri);
+        return $this->crawl($schema);
     }
 
     /**

--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -40,6 +40,7 @@ class Dereferencer
 
         if ($uri) {
             $schema = $this->loadExternalRef($uri);
+            $schema = $this->resolveFragment($uri, $schema);
         }
 
         return $this->crawl($schema, strip_fragment($uri));

--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -329,7 +329,14 @@ class Dereferencer
         foreach (array_slice(explode('/', $path), 1) as $segment) {
             $currentPath .= '/' . $segment;
             if ($pointer->has($currentPath . '/id')) {
-                $scope .= $pointer->get($currentPath . '/id');
+                $id = $pointer->get($currentPath . '/id');
+                // If the ID is a relative reference, append it to the current scope.
+                // Otherwise we completely replace the scope.
+                if ($this->isRelativeRef($id)) {
+                    $scope .= $id;
+                } else {
+                    $scope = $id;
+                }
             }
         }
         $ref = $scope . $ref;

--- a/src/functions.php
+++ b/src/functions.php
@@ -161,9 +161,7 @@ function compare($leftOperand, $rightOperand)
  */
 function strip_fragment($ref)
 {
-    if ($hashPos = strrpos($ref, '#')) {
-        return substr($ref, 0, $hashPos);
-    }
+    $fragment = parse_url($ref, PHP_URL_FRAGMENT);
 
-    return $ref;
+    return $fragment ? str_replace($fragment, '', $ref) : $ref;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -154,6 +154,8 @@ function compare($leftOperand, $rightOperand)
 }
 
 /**
+ * Removes the fragment from a reference.
+ *
  * @param  string $ref
  * @return string
  */

--- a/src/functions.php
+++ b/src/functions.php
@@ -152,3 +152,16 @@ function compare($leftOperand, $rightOperand)
 {
     return Comparator::compare($leftOperand, $rightOperand);
 }
+
+/**
+ * @param  string $ref
+ * @return string
+ */
+function strip_fragment($ref)
+{
+    if ($hashPos = strrpos($ref, '#')) {
+        return substr($ref, 0, $hashPos);
+    }
+
+    return $ref;
+}

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -29,6 +29,21 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result->definitions->positiveIntegerDefault0, $result->properties->minItems->resolve());
     }
 
+    public function testRemoteWithoutId()
+    {
+        $deref  = new Dereferencer();
+        $result = $deref->dereference('http://localhost:1234/albums.json');
+
+        $this->assertSame('string', $result->items->properties->title->type);
+    }
+
+    public function testRemoteWithoutIdThrowsIfDereferencingAnObject()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $deref  = new Dereferencer();
+        $result = $deref->dereference(json_decode('{"$ref": "album.json"}'));
+    }
+
     public function testRecursiveRootPointer()
     {
         $deref  = new Dereferencer();

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -44,6 +44,13 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $result = $deref->dereference(json_decode('{"$ref": "album.json"}'));
     }
 
+    public function testRemoteWithFragment()
+    {
+        $deref  = new Dereferencer();
+        $result = $deref->dereference('http://localhost:1234/subSchemas.json#/relativeRefToInteger');
+        $this->assertSame(['type' => 'integer'], (array) $result);
+    }
+
     public function testRecursiveRootPointer()
     {
         $deref  = new Dereferencer();

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -34,6 +34,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         }, glob(schema_test_suite_path() . '/draft4/*.json'));
     }
 
+    public function unofficialTests()
+    {
+        return array_map(function ($file) {
+            return [$file];
+        }, glob(__DIR__ . '/unofficial/*.json'));
+    }
+
     /**
      * @dataProvider allDraft4Tests
      *
@@ -57,6 +64,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testDraft4CoreTestsPassWithoutBcMath($testFile)
     {
         require __DIR__ . '/disable_bccomp.php';
+        $test = json_decode(file_get_contents($testFile));
+
+        $this->runTestCase($test);
+    }
+
+    /**
+     * @dataProvider unofficialTests
+     */
+    public function testUnofficialTests($testFile)
+    {
         $test = json_decode(file_get_contents($testFile));
 
         $this->runTestCase($test);

--- a/tests/server.js
+++ b/tests/server.js
@@ -14,9 +14,15 @@ var remotes = {
         },
         "refToInteger": {
             "$ref": "#/integer"
+        },
+        // added to test relative references without id,
+        // when the inital schema is loaded from an object
+        // but the parent of the relative ref was retrieved by URI.
+        "relativeRefToInteger": {
+            "$ref": "integer.json"
         }
     },
-    // added by us
+    // added to test relative references without id
     "album.json": {
         "type": "object",
         "properties": {

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,7 +1,7 @@
 var http = require('http');
 
-// from vendor/json-schema/JSON-Schema-Test-Suite/bin/jsonschema_suite remotes
 var remotes = {
+    // from vendor/json-schema/JSON-Schema-Test-Suite/bin/jsonschema_suite remotes
     "folder/folderInteger.json": {
         "type": "integer"
     },
@@ -14,6 +14,19 @@ var remotes = {
         },
         "refToInteger": {
             "$ref": "#/integer"
+        }
+    },
+    // added by us
+    "album.json": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"}
+        }
+    },
+    "albums.json": {
+        "type": "array",
+        "items": {
+            "$ref": "album.json"
         }
     }
 };

--- a/tests/unofficial/refRemote.json
+++ b/tests/unofficial/refRemote.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "change resolution scope with absolute id",
+        "schema": {
+            "id": "http://localhost:1234/",
+            "items": {
+                "id": "http://localhost:1234/folder/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "changed scope ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "changed scope ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Initial resolution scope is the URI of the schema",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/relativeRefToInteger"
+        },
+        "tests": [
+            {
+                "description": "relative ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "relative ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This PR improves dereferencing when the schema does not have an ID, when a nested ID is an absolute URI, and when the initial schema is loaded with a reference fragment.

## Initial Scope When There Isn't An ID

### The Spec

This is the part of the spec this addresses:

> The initial resolution scope of a schema is the URI of the schema itself, if any, or the empty URI if the schema was not loaded from a URI.

> The "id" keyword (or "id", for short) is used to alter the resolution scope. When an id is encountered, an implementation MUST resolve this id against the most immediate parent scope. The resolved URI will be the new resolution scope for this subschema and all its children, until another id is encountered.

### Implementation

When resolving a relative reference, there are a few scenarios possible:

#### The initial schema is loaded from an object, and the dereferencer encounters a relative reference when an ID is not present.

If this happens we can't possibly resolve the relative reference, because we don't have the ID or the URI the schema is loaded from.  An InvalidArgumentException is thrown because the path is not valid.

#### The initial schema is loaded from a path, and the dereferencer encounters a relative reference when an ID is not present.

If this happens the URI of the schema itself is used as the initial scope.  The dereferencer will attempt to load the schema relative to the current URI.

#### The initial schema is loaded from an object, then loads an absolute reference, and *then* encounters a relative reference when an ID is not present.

If this happens the dereferencer will attempt to load the schema relative to the URI of the last absolute reference loaded.

## Scope Resolution With Absolute References For IDs

### The Spec

The spec includes this example:

```json
{
    "id": "http://x.y.z/rootschema.json#",
    "schema1": {
        "id": "#foo"
    },
    "schema2": {
        "id": "otherschema.json",
        "nested": {
            "id": "#bar"
        },
        "alsonested": {
            "id": "t/inner.json#a"
        }
    },
    "schema3": {
        "id": "some://where.else/completely#"
    }
}
```

### Implementation

To solve this, we just check if the ID is an absolute reference (begins with a prefix).  if the ID is absolute, we set the scope to the ID.  Otherwise we continue appending like normal.

```
#/schema3 should resolve to:
some://where.else/completely#
```

## Loading Paths with Fragments

### The Spec

This addresses this part of the JSON Reference spec:

> If a URI contains a fragment identifier, then the fragment should be
   resolved per the fragment resolution mechansim of the referrant
   document.  If the representation of the referrant document is JSON,
   then the fragment identifier SHOULD be interpreted as a
   [JSON-Pointer].

### The Implementation

Before we didn't check for fragments when loading the schema.  Now we check if a fragment exists, and if so resolve the schema at that fragment instead of the entire schema before we begin dereferencing.

References:

https://spacetelescope.github.io/understanding-json-schema/structuring.html#the-id-property
http://json-schema.org/latest/json-schema-core.html#anchor26
https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-4