### PR TITLE
Tell which properties are missing

### DIFF
--- a/src/Constraints/Required.php
+++ b/src/Constraints/Required.php
@@ -20,7 +20,7 @@ class Required implements PropertyConstraint
         $missing          = array_diff($parameter, $actualProperties);
         if (count($missing)) {
             return new ValidationError(
-                'Required properties missing.',
+                'Required properties missing: ' . implode(', ', array_values($missing)),
                 ErrorCode::MISSING_REQUIRED,
                 $data,
                 $pointer,

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace League\JsonGuard\Test\Constraints;
+
+use League\JsonGuard\Constraints\Required;
+
+class RequiredTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExceptionMessageContainsPropertyName()
+    {
+        $required = new Required();
+        $error = $required->validate(new \StdClass(), ['shouldBeHere']);
+        $this->assertRegExp('/shouldBeHere/', $error->getMessage());
+    }
+}
+


### PR DESCRIPTION
At the moment the exception only tells that fields are missing, but it doesnt tell which fields. Giving back the field-names is very helpful.