### PR TITLE
Non string values should fail format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * You can now use pointers when using the file loader, I.E. 'file://my-schema.json#/some/property'.
+* Fixed a bug where non string values passed to `format` caused an error if they weren't caught by type validation.
 
 ## 0.3.3 - 2016-08-22
 

--- a/src/Constraints/Format.php
+++ b/src/Constraints/Format.php
@@ -86,7 +86,7 @@ class Format implements PropertyConstraint
      */
     private static function validateRegex($format, $value, $pattern, $errorCode, $pointer)
     {
-        if (preg_match($pattern, $value) === 1) {
+        if (is_string($value) && preg_match($pattern, $value) === 1) {
             return null;
         }
 
@@ -105,7 +105,7 @@ class Format implements PropertyConstraint
      */
     private static function validateFilter($format, $value, $filter, $options, $errorCode, $pointer)
     {
-        if (filter_var($value, $filter, $options) !== false) {
+        if (is_string($value) && filter_var($value, $filter, $options) !== false) {
             return null;
         }
 

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace League\JsonGuard\Test\Constraints;
+
+use League\JsonGuard\Constraints\Format;
+use League\JsonGuard\ValidationError;
+
+class FormatTest extends \PHPUnit_Framework_TestCase
+{
+    public function invalidFormatValues()
+    {
+        return [
+            [[], 'date-time'],
+            [new \stdClass(), 'uri'],
+            [1234, 'email'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidFormatValues
+     */
+    public function testFormatFailsForNonStringValues($value, $parameter)
+    {
+        $format = new Format();
+        $result = $format::validate($value, $parameter);
+        $this->assertInstanceOf(ValidationError::class, $result);
+    }
+
+} 


### PR DESCRIPTION
All of the built in format validation rules require strings.  This
does not affect custom format validation rules, as those can apply
to other types.