### PR TITLE
Improve URI Resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "sabre/uri": "~1.1"
     },
     "suggest": {
         "ext-bcmath": "Required to properly check constraints for numbers larger than PHP_INT_MAX."

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -135,4 +135,11 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_object($result->properties->$ref));
         $this->assertSame($result->properties->$ref->description, 'The name of the property is $ref, but it\'s not a reference.');
     }
+
+    public function testProperlyResolvesRelativeScopeAgainstAnAbsoluteId()
+    {
+        $deref = new Dereferencer();
+        $result = $deref->dereference(json_decode('{"id": "http://localhost:1234/test.json", "properties": {"album": {"$ref": "album.json"}}}'));
+        $this->assertSame('object', $result->properties->album->type);
+    }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -31,4 +31,28 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse(\League\JsonGuard\is_json_integer($jsonInteger));
         }
     }
+
+    public function testUris()
+    {
+        return [
+            ['http://x.y.z/rootschema.json#', '', 'http://x.y.z/rootschema.json#'],
+            ['#foo', 'http://x.y.z/rootschema.json#', 'http://x.y.z/rootschema.json#foo'],
+            // Technically the spec adds the superfluous # at the end, but we don't need to enforce that.
+            ['otherschema.json', 'http://x.y.z/rootschema.json#', 'http://x.y.z/otherschema.json'],
+            ['#bar', 'http://x.y.z/otherschema.json#', 'http://x.y.z/otherschema.json#bar'],
+            ['t/inner.json#a', 'http://x.y.z/otherschema.json#', 'http://x.y.z/t/inner.json#a'],
+            ['some://where.else/completely#', 'http://x.y.z/rootschema.json#', 'some://where.else/completely#'],
+            ['folderInteger.json', 'http://localhost:1234/folder/', 'http://localhost:1234/folder/folderInteger.json'],
+            ['some-id.json', '', 'some-id.json'],
+        ];
+    }
+
+    /**
+     * @dataProvider testUris
+     */
+    public function testResolveUri($id, $parentScope, $expectedResult)
+    {
+        $result = \League\JsonGuard\resolve_uri($id, $parentScope);
+        $this->assertSame($expectedResult, $result);
+    }
 }


### PR DESCRIPTION
This PR improves how we resolve relative Uris against the current resolution scope.  Previously we were doing a really naive replacement of the current filename with the relative URI.  This would break if the relative URI had a fragment or the resolution scope ended in a path like `http://mydomain.dev/somewhere/`.

To make URI resolution easier this PR introduces a dependency on [sabre/uri](https://packagist.org/packages/sabre/uri).  We are using it to provide the opposite of `parse_url`, `Sabre\Uri\build`.  It doesn't have any dependencies besides `php: >=5.4.7` and it's licensed `BSD-3`.

This fixes the error encountered in #49.