### PR TITLE
Refactor error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+* Major breaking changes were made to the ValidationError class.
+    * Any calls to `ValidationError@getConstraint` need to be changed to `ValidationError@getContext`.
+    * If you are using the `ArrayAccess` interface for `ValidationError` you need to replace any usage of the `constraints` key with `context`.
+    * Unlike the old constraints array, every entry in the context array is a string. This makes implementing your own error messages a lot easier.
+
 ### Fixed
 
 * Type number was passing for numeric strings when it should not have been.

--- a/docs/validation/errors.md
+++ b/docs/validation/errors.md
@@ -12,17 +12,17 @@ The validator returns detailed errors for each validation failure.  Calling the 
 [
  [
    "code"        => 50,
-   "message"     => "'json-guard.dev/schema#' is not a valid uri.",
+   "message"     => "Value 'json-guard.dev/schema#' does not match the format 'uri'",
    "pointer"     => "/id",
    'value'       => 'json-guard.dev/schema#',
-   'constraints' => null,
+   'context'     => ['value' => 'json-guard.dev/schema#', 'format' => 'uri'],
  ],
  [
    "code"        => 25,
    "message"     => "Value '2192191' is not a string.",
    "pointer"     => "/name",
    'value'       => 2192191,
-   'constraints' => null,
+   'context'     => ['value' => '"2192191"'],
  ]
 ]
 ```
@@ -37,6 +37,8 @@ The code is a unique identifier for this error type.  You can view the complete 
 
 The message is a developer friendly explanation of what caused the error.
 
+The `message` is intended for developers and is not localized.  Error messages can be easily localized for your application using the error code, the context, and the [symfony/translation](http://symfony.com/doc/current/components/translation/usage.html) component or a similar library.
+
 ### Pointer
 
 The pointer is a [JSON Pointer](https://tools.ietf.org/html/rfc6901) to the attribute that caused the error.
@@ -45,10 +47,9 @@ The pointer is a [JSON Pointer](https://tools.ietf.org/html/rfc6901) to the attr
 
 The value that caused the error.
 
-### Constraints
+### Context
 
-Any constraints applied to the validation rule.  For example, the schema `{"minimum": 2}` would return the contraint `['min' => 2]`.
+The context array holds any data meant to be interpolated into the error message.  For example, the schema `{"minimum": 2}` and the data `1` would return the context `['value' => '1, min' => 2]`.
 
-## Localization
+Every value in the array is cast to a string so that it can be safely interpolated.
 
-The `message` is intended for developers and is not localized.  Error messages can be easily localized for your application using the error codes and the [symfony/translation](http://symfony.com/doc/current/components/translation/usage.html) component or a similar library.

--- a/docs/validation/overview.md
+++ b/docs/validation/overview.md
@@ -54,9 +54,9 @@ Errors for failing validation are retrieved by calling the `errors` method.  For
 
 ## Limiting Depth
 
-Because circular references are allowed and sometimes neccessary, the validator will continue recursively validating the JSON data until it runs out of data.
+Because circular references are allowed and sometimes necessary, the validator will continue recursively validating the JSON data until it runs out of data.
 
-This means a payload like this with a cooresponding schema could cause the validator to continue to run for a _very_ long time:
+This means a payload like this with a corresponding schema could cause the validator to continue to run for a _very_ long time:
 
 ```json
 // data:

--- a/src/Constraints/AdditionalProperties.php
+++ b/src/Constraints/AdditionalProperties.php
@@ -30,9 +30,9 @@ class AdditionalProperties implements ParentSchemaAwareContainerInstanceConstrai
         }
 
         if ($parameter === false) {
-            $message = sprintf('Additional properties are not allowed: "%s".', implode('", "', $diff));
-
-            return new ValidationError($message, ErrorCode::NOT_ALLOWED_PROPERTY, $data, $pointer);
+            $message = 'Additional properties found which are not allowed: {diff}';
+            $context = ['diff' => implode(', ', $diff)];
+            return new ValidationError($message, ErrorCode::NOT_ALLOWED_PROPERTY, $data, $pointer, $context);
         } elseif (is_object($parameter)) {
             // If additionalProperties is an object it's a schema,
             // so validate all additional properties against it.

--- a/src/Constraints/Dependencies.php
+++ b/src/Constraints/Dependencies.php
@@ -46,7 +46,7 @@ class Dependencies implements ContainerInstanceConstraint
         foreach ($dependencies as $dependency) {
             if (!in_array($dependency, array_keys(get_object_vars($data)), true)) {
                 $errors[] = new ValidationError(
-                    sprintf('Unmet dependency "%s"', $dependency),
+                    'Unmet dependency {dependency}',
                     ErrorCode::UNMET_DEPENDENCY,
                     $data,
                     $pointer,

--- a/src/Constraints/Enum.php
+++ b/src/Constraints/Enum.php
@@ -21,11 +21,12 @@ class Enum implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Value "%s" is not one of: %s',
-            JsonGuard\as_string($value),
-            implode(', ', array_map('League\JsonGuard\as_string', $parameter))
+        return new ValidationError(
+            'Value {value} is not one of: {choices}',
+            ErrorCode::INVALID_ENUM,
+            $value,
+            $pointer,
+            ['choices' => $parameter, 'value' => $value]
         );
-        return new ValidationError($message, ErrorCode::INVALID_ENUM, $value, $pointer, ['choices' => $parameter]);
     }
 }

--- a/src/Constraints/Format.php
+++ b/src/Constraints/Format.php
@@ -90,7 +90,13 @@ class Format implements PropertyConstraint
             return null;
         }
 
-        return new ValidationError(self::invalidFormatMessage($format, $value), $errorCode, $value, $pointer);
+        return new ValidationError(
+            'Value {value} does not match the format {format}',
+            $errorCode,
+            $value,
+            $pointer,
+            ['value' => $value, 'format' => $format]
+        );
     }
 
     /**
@@ -117,17 +123,12 @@ class Format implements PropertyConstraint
             }
         }
 
-        return new ValidationError(self::invalidFormatMessage($format, $value), $errorCode, $value, $pointer);
-    }
-
-    /**
-     * @param string $format
-     * @param mixed  $value
-     *
-     * @return string
-     */
-    private static function invalidFormatMessage($format, $value)
-    {
-        return sprintf('"%s" is not a valid %s.', JsonGuard\as_string($value), $format);
+        return new ValidationError(
+            'Value {value} does not match the format {format}',
+            $errorCode,
+            $value,
+            $pointer,
+            ['value' => $value, 'format' => $format]
+        );
     }
 }

--- a/src/Constraints/Max.php
+++ b/src/Constraints/Max.php
@@ -34,12 +34,13 @@ class Max implements ParentSchemaAwarePropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Number "%s" is not at most "%d"',
-            JsonGuard\as_string($value),
-            JsonGuard\as_string($parameter)
+        return new ValidationError(
+            'Value {value} is not at most {max}',
+            ErrorCode::INVALID_MAX,
+            $value,
+            $pointer,
+            ['value' => $value, 'max' => $parameter]
         );
-        return new ValidationError($message, ErrorCode::INVALID_MAX, $value, $pointer, ['max' => $parameter]);
     }
 
     /**
@@ -55,17 +56,12 @@ class Max implements ParentSchemaAwarePropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Number "%s" is not less than "%d"',
-            JsonGuard\as_string($value),
-            JsonGuard\as_string($parameter)
-        );
         return new ValidationError(
-            $message,
+            'Value {value} is not less than {exclusive_max}',
             ErrorCode::INVALID_EXCLUSIVE_MAX,
             $value,
             $pointer,
-            ['exclusive_max' => $parameter]
+            ['value' => $value, 'exclusive_max' => $parameter]
         );
     }
 }

--- a/src/Constraints/MaxItems.php
+++ b/src/Constraints/MaxItems.php
@@ -17,9 +17,8 @@ class MaxItems implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Array does not contain less than "%d" items', JsonGuard\as_string($parameter));
         return new ValidationError(
-            $message,
+            'Array does not contain less than {max_items} items',
             ErrorCode::MAX_ITEMS_EXCEEDED,
             $value,
             $pointer,

--- a/src/Constraints/MaxLength.php
+++ b/src/Constraints/MaxLength.php
@@ -17,9 +17,8 @@ class MaxLength implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('String is not at most "%s" characters long', JsonGuard\as_string($parameter));
         return new ValidationError(
-            $message,
+            'String is not at most {max_length} characters long',
             ErrorCode::INVALID_MAX_LENGTH,
             $value,
             $pointer,

--- a/src/Constraints/MaxProperties.php
+++ b/src/Constraints/MaxProperties.php
@@ -17,9 +17,8 @@ class MaxProperties implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Object does not contain less than "%d" properties', JsonGuard\as_string($parameter));
         return new ValidationError(
-            $message,
+            'Object does not contain less than {max_properties} properties',
             ErrorCode::MAX_PROPERTIES_EXCEEDED,
             $value,
             $pointer,

--- a/src/Constraints/Min.php
+++ b/src/Constraints/Min.php
@@ -34,13 +34,13 @@ class Min implements ParentSchemaAwarePropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Number "%s" is not at least "%d"',
-            JsonGuard\as_string($value),
-            JsonGuard\as_string($parameter)
+        return new ValidationError(
+            'Number {value} is not at least {min}',
+            ErrorCode::INVALID_MIN,
+            $value,
+            $pointer,
+            ['value' => $value, 'min' => $parameter]
         );
-
-        return new ValidationError($message, ErrorCode::INVALID_MIN, $value, $pointer, ['min' => $parameter]);
     }
 
     /**
@@ -56,18 +56,12 @@ class Min implements ParentSchemaAwarePropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Number "%s" is not at least greater than "%d"',
-            JsonGuard\as_string($value),
-            JsonGuard\as_string($parameter)
-        );
-
         return new ValidationError(
-            $message,
+            'Number {value} is not at least greater than {exclusive_min}',
             ErrorCode::INVALID_EXCLUSIVE_MIN,
             $value,
             $pointer,
-            ['exclusive_min' => $parameter]
+            ['value' => $value, 'exclusive_min' => $parameter]
         );
     }
 }

--- a/src/Constraints/MinItems.php
+++ b/src/Constraints/MinItems.php
@@ -17,9 +17,8 @@ class MinItems implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Array does not contain more than "%d" items', JsonGuard\as_string($parameter));
         return new ValidationError(
-            $message,
+            'Array does not contain more than {min_items} items',
             ErrorCode::INVALID_MIN_COUNT,
             $value,
             $pointer,

--- a/src/Constraints/MinLength.php
+++ b/src/Constraints/MinLength.php
@@ -17,10 +17,8 @@ class MinLength implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('String is not at least "%s" characters long', JsonGuard\as_string($parameter));
-
         return new ValidationError(
-            $message,
+            'String is not at least {min_length} characters long',
             ErrorCode::INVALID_MIN_LENGTH,
             $value,
             $pointer,

--- a/src/Constraints/MinProperties.php
+++ b/src/Constraints/MinProperties.php
@@ -17,9 +17,8 @@ class MinProperties implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Object does not contain at least "%d" properties', JsonGuard\as_string($min));
         return new ValidationError(
-            $message,
+            'Object does not contain at least {min_properties} properties',
             ErrorCode::INVALID_MIN_COUNT,
             $value,
             $pointer,

--- a/src/Constraints/MultipleOf.php
+++ b/src/Constraints/MultipleOf.php
@@ -24,17 +24,12 @@ class MultipleOf implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf(
-            'Number "%d" is not a multiple of "%d"',
-            JsonGuard\as_string($value),
-            JsonGuard\as_string($multiple)
-        );
         return new ValidationError(
-            $message,
+            'Number {value} is not a multiple of {multiple_of}',
             ErrorCode::INVALID_MULTIPLE,
             $value,
             $pointer,
-            ['multiple_of' => $multiple]
+            ['value' => $value, 'multiple_of' => $multiple]
         );
     }
 }

--- a/src/Constraints/Pattern.php
+++ b/src/Constraints/Pattern.php
@@ -21,7 +21,12 @@ class Pattern implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Value "%s" does not match the given pattern.', JsonGuard\as_string($value));
-        return new ValidationError($message, ErrorCode::INVALID_PATTERN, $value, $pointer, ['pattern' => $pattern]);
+        return new ValidationError(
+            'Value {value} does not match the pattern {pattern}.',
+            ErrorCode::INVALID_PATTERN,
+            $value,
+            $pointer,
+            ['value' => $value, 'pattern' => $pattern]
+        );
     }
 }

--- a/src/Constraints/Required.php
+++ b/src/Constraints/Required.php
@@ -20,11 +20,11 @@ class Required implements PropertyConstraint
         $missing          = array_diff($parameter, $actualProperties);
         if (count($missing)) {
             return new ValidationError(
-                'Required properties missing: ' . implode(', ', array_values($missing)),
+                'Required properties missing: {missing}',
                 ErrorCode::MISSING_REQUIRED,
                 $data,
                 $pointer,
-                ['required' => $parameter]
+                ['missing' => array_values($missing)]
             );
         }
 

--- a/src/Constraints/Type.php
+++ b/src/Constraints/Type.php
@@ -79,9 +79,13 @@ class Type implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Value "%s" is not a(n) %s.', JsonGuard\as_string($value), $type);
-
-        return new ValidationError($message, $errorCode, $value, $pointer);
+        return new ValidationError(
+            'Value {value} is not a(n) {type}',
+            $errorCode,
+            $value,
+            $pointer,
+            ['value' => $value, 'type' => $type]
+        );
     }
 
     /**
@@ -100,12 +104,15 @@ class Type implements PropertyConstraint
             }
         }
 
-        $message = sprintf(
-            'Value "%s" is not one of: %s',
-            JsonGuard\as_string($value),
-            implode(', ', array_map('League\JsonGuard\as_string', $choices))
+        return new ValidationError(
+            'Value {value} is not one of: {choices}',
+            ErrorCode::INVALID_TYPE,
+            $value,
+            $pointer,
+            [
+                'value'   => $value,
+                'choices' => $choices
+            ]
         );
-
-        return new ValidationError($message, ErrorCode::INVALID_TYPE, $value, $pointer, ['types' => $choices]);
     }
 }

--- a/src/Constraints/UniqueItems.php
+++ b/src/Constraints/UniqueItems.php
@@ -21,7 +21,12 @@ class UniqueItems implements PropertyConstraint
             return null;
         }
 
-        $message = sprintf('Array "%s" is not unique.', JsonGuard\as_string($value));
-        return new ValidationError($message, ErrorCode::NOT_UNIQUE_ITEM, $value, $pointer);
+        return new ValidationError(
+            'Array {value} is not unique.',
+            ErrorCode::NOT_UNIQUE_ITEM,
+            $value,
+            $pointer,
+            ['value' => $value]
+        );
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -48,35 +48,11 @@ function strlen($string)
  */
 function as_string($value)
 {
-    if (is_string($value)) {
-        return $value;
-    }
-
-    if (is_int($value)) {
-        return (string)$value;
-    }
-
-    if (is_bool($value)) {
-        return $value ? '<TRUE>' : '<FALSE>';
-    }
-
-    if (is_object($value)) {
-        return get_class($value);
-    }
-
-    if (is_array($value)) {
-        return '<ARRAY>';
-    }
-
     if (is_resource($value)) {
         return '<RESOURCE>';
     }
 
-    if (is_null($value)) {
-        return '<NULL>';
-    }
-
-    return '<UNKNOWN>';
+    return (string) json_encode($value);
 }
 
 /**


### PR DESCRIPTION
I tried to write a translation package and realized how annoying the errors are to work with.

This is a BC break but I think it will be worth it.

Changes:

- the error 'constraints' were replaced with a 'context' array.  The context contains anything that is meant to be interpolated into the error message.  This closes #32 since we can put all of the relevant attributes in the context.
    - Any calls to `ValidationError@getConstraints` need to be changed to `ValidationError@getContext`.
    - If you are using the `ArrayAccess` interface for `ValidationError` you need to replace any calls to `constraints` with `context`.

- Every entry in the context array is a string.  This makes implementing your own error messages a lot easier.

- Instead of using sprintf the messages use mustache placeholders and are interpolated when retrieved.  This means we added some extra entries to the context that weren't in constraints, like `value`.

- the `as_string` method now justs `json_encode`s the data to get the string representation.  Since the data came from JSON we can assume it will re-encode.  This is generally a lot more readable since arrays will look like `"[1,2,3]"` instead of `<ARRAY>`.

Todo:

- [x] Update the changelog
- [x] Test the error messages more thoroughly.