### PR TITLE
Only encode context as string once

### DIFF
--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -67,7 +67,7 @@ class ValidationError implements \ArrayAccess, \JsonSerializable
     {
         $replace = [];
         foreach ($context as $key => $val) {
-            $replace['{' . $key . '}'] = as_string($val);
+            $replace['{' . $key . '}'] = $val;
         }
 
         return strtr($message, $replace);

--- a/tests/ValidationErrorTest.php
+++ b/tests/ValidationErrorTest.php
@@ -17,7 +17,7 @@ class ValidationErrorTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame(
-            'Value "-5" must be greater than "0"',
+            'Value -5 must be greater than 0',
             $e->getMessage()
         );
     }


### PR DESCRIPTION
I introduced a bug where the context array is encoded as a string twice.
It only needs to be encoded once.