### PR TITLE
Allow redirects with the CurlWebLoader

### DIFF
--- a/src/Loaders/CurlWebLoader.php
+++ b/src/Loaders/CurlWebLoader.php
@@ -65,6 +65,8 @@ class CurlWebLoader implements Loader
     {
         return [
             CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS      => 20,
         ];
     }
 


### PR DESCRIPTION
This changes the CurlWebLoader to allow redirects like the
FileGetContentsWebLoader.  The max is set to 20, the same default PHP
uses for file_get_contents.

It's pretty common for a schema to move from the location that
is referenced in an id.  For example, the swagger schema has moved
from swagger.io/v2/schema.json but that is still the canonical URL.