### PR TITLE
Fixed error with nested reference validations.

### DIFF
--- a/src/Reference.php
+++ b/src/Reference.php
@@ -10,7 +10,7 @@ use Closure;
  * impossible.  This object can be substituted for the $ref instead,
  * allowing lazy resolution of the $ref when needed.
  */
-class Reference implements \JsonSerializable, \IteratorAggregate
+class Reference implements \JsonSerializable
 {
     /**
      * A JSON object resulting from a json_decode call or a Closure.
@@ -19,8 +19,6 @@ class Reference implements \JsonSerializable, \IteratorAggregate
      * @var object|Closure
      */
     private $schema;
-
-    private $cached;
 
     /**
      * A valid JSON reference.  The reference should point to a location in $schema.
@@ -63,15 +61,10 @@ class Reference implements \JsonSerializable, \IteratorAggregate
      */
     public function resolve()
     {
-        if (empty($this->cached)) {
-            if ($this->schema instanceof Closure) {
-                return $this->resolveExternalReference();
-            }
-
-            return $this->resolveInternalReference();
+        if ($this->schema instanceof Closure) {
+            return $this->resolveExternalReference();
         }
-
-        return $this->cached;
+        return $this->resolveInternalReference();
     }
 
     /**
@@ -113,10 +106,5 @@ class Reference implements \JsonSerializable, \IteratorAggregate
         }
 
         throw new \InvalidArgumentException(sprintf('Unknown property "%s"', $property));
-    }
-
-    public function getIterator()
-    {
-        return new \ArrayIterator($this->resolve());
     }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -75,7 +75,8 @@ class Validator implements SubSchemaValidatorFactory
             );
         }
 
-        if ($schema instanceof Reference) {
+
+        while ($schema instanceof Reference) {
             $schema = $schema->resolve();
         }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -308,6 +308,23 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $v = new Validator([], (object) ['minimum' => 0], new InvalidRulesetStub());
         $v->errors();
     }
+
+
+    public function testNestedReference() {
+        $deref = new Dereferencer();
+        $path   = 'file://' . __DIR__ . '/fixtures/client.json';
+        $schema = $deref->dereference($path);
+
+        $validator = new Validator((object) [
+            'name' => 'Test user',
+            'phone' => 'some-phone',
+            'company' => (object) [
+                'name' => 'some-company'
+            ]
+        ], $schema);
+
+        $this->assertTrue($validator->fails());
+    }
 }
 
 class InvalidRulesetStub implements JsonGuard\RuleSet

--- a/tests/fixtures/client.json
+++ b/tests/fixtures/client.json
@@ -1,0 +1,14 @@
+{
+    "definitions": {
+        "company": {
+            "$ref": "company.json"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "phone": { "type": "string" },
+        "company": { "$ref": "#/definitions/company" }
+    },
+    "required": ["name", "phone", "company"]
+}

--- a/tests/fixtures/company.json
+++ b/tests/fixtures/company.json
@@ -1,0 +1,8 @@
+{
+    "properties": {
+        "id": { "type": "integer" },
+        "name": { "type": "string" }
+    },
+    "required": ["id", "name"],
+    "type": "object"
+}


### PR DESCRIPTION
As I wrote in #83 I had issue with loading external schemas.

In this PR I try fix this issue because I found that $this->schema work wrong as Iterator if it is `\League\JsonGuard\Reference`. In all cases this returns empty iterator. I fix it by adding `\IteratorAggregate` to `\League\JsonGuard\Reference` and add cached field to prevent multiple requests to same resource.