### PR TITLE
Always strip the fragment when loading external refs

### DIFF
--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -307,6 +307,7 @@ class Dereferencer
     {
         $this->validateAbsolutePath($reference);
         list($prefix, $path) = explode('://', $reference, 2);
+        $path = rtrim(strip_fragment($path), '#');
 
         $loader = $this->getLoader($prefix);
 

--- a/src/Loaders/FileLoader.php
+++ b/src/Loaders/FileLoader.php
@@ -13,7 +13,6 @@ class FileLoader implements Loader
      */
     public function load($path)
     {
-        $path = rtrim(JsonGuard\strip_fragment($path), '#');
         if (!file_exists($path)) {
             throw SchemaLoadingException::notFound($path);
         }

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -22,7 +22,7 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
     public function testRemote()
     {
         $loader = new ArrayLoader(
-            ['json-schema.org/draft-04/schema#' => file_get_contents(__DIR__ . '/fixtures/draft4-schema.json')]
+            ['json-schema.org/draft-04/schema' => file_get_contents(__DIR__ . '/fixtures/draft4-schema.json')]
         );
         $deref  = new Dereferencer();
         $deref->registerLoader($loader, 'http');


### PR DESCRIPTION
We resolve the fragment after loading so if the loader actually did
attempt to resolve the fragment it would be resolved twice and fail.