### PR TITLE
Extract a parse_external_ref function

### DIFF
--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -241,12 +241,8 @@ class Dereferencer
      */
     private function loadExternalRef($reference)
     {
-        $this->validateAbsolutePath($reference);
-        list($prefix, $path) = explode('://', $reference, 2);
-        $path = rtrim(strip_fragment($path), '#');
-
+        list($prefix, $path) = parse_external_ref($reference);
         $loader = $this->getLoader($prefix);
-
         $schema = $loader->load($path);
 
         return $schema;
@@ -264,24 +260,6 @@ class Dereferencer
         unset($rootSchema->$ref);
         foreach (get_object_vars($resolvedRef) as $prop => $value) {
             $rootSchema->$prop = $value;
-        }
-    }
-
-    /**
-     * Validate an absolute path is valid.
-     *
-     * @param string $path
-     */
-    private function validateAbsolutePath($path)
-    {
-        if (!preg_match('#^.+\:\/\/.*#', $path)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Your path  "%s" is missing a valid prefix.  ' .
-                    'The schema path should start with a prefix i.e. "file://".',
-                    $path
-                )
-            );
         }
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -195,6 +195,33 @@ function is_internal_ref($value)
 }
 
 /**
+ * Parse an external reference returning the prefix and path.
+ *
+ * @param string $ref
+ *
+ * @return array
+ *
+ * @throws \InvalidArgumentException
+ */
+function parse_external_ref($ref)
+{
+    if (is_relative_ref($ref)) {
+        throw new \InvalidArgumentException(
+            sprintf(
+                'The path  "%s" was expected to be an external reference but is missing a prefix.  ' .
+                'The schema path should start with a prefix i.e. "file://".',
+                $ref
+            )
+        );
+    }
+
+    list($prefix, $path) = explode('://', $ref, 2);
+    $path = rtrim(strip_fragment($path), '#');
+
+    return [$prefix, $path];
+}
+
+/**
  * Resolve the given id against the parent scope and return the resolved URI.
  *
  * @param string $id          The id to resolve.  This should be a valid relative or absolute URI.


### PR DESCRIPTION
Moving this logic to a function means it can be re-used.  Getting ready for #60.