### PR TITLE
Move loader registration to a LoaderManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Allow redirects by default with the CurlWebLoader.
 * All constraints now implement a single interface.  See `League\JsonGuard\Constraints\Constraint` for more info.  If you are using custom constraints you should update them to match the new signature.
-
+* The Dereferencer now accepts a LoaderManager which takes care of registering and getting schema loaders.  You should replace any calls to `Dereferencer::getLoader`, `Dereferencer::getLoaders`, or `Dereferencer::registerLoader` with `Dereferencer::getLoaderManager` and then call the method on the loader manager.  The order of arguments for `LoaderManager::registerLoader` was also changed;
 
 ## 0.5.1 - 2016-11-28
 

--- a/docs/dereferencing/overview.md
+++ b/docs/dereferencing/overview.md
@@ -73,7 +73,7 @@ You can make your own loaders by implementing the [Loader Interface](https://git
 { "$ref":"couchdb://00a271787f89c0ef2e10e88a0c0001f4" }
 ```
 
-Once you have written your custom loader, you can register it with the dereferencer.  The first argument should be the loader instance, and the second argument should be the prefix you would like to load references for.
+Once you have written your custom loader, you can register it with the dereferencer's `LoaderManager`.  The first argument should be the loader instance, and the second argument should be the prefix you would like to load references for.
 
 ```php
 <?php
@@ -83,5 +83,5 @@ use My\App\CouchDbLoader;
 $couchLoader = new CouchDbLoader();
 $deref  = new League\JsonGuard\Dereferencer();
 
-$deref->registerLoader($couchLoader, 'couchdb');
+$deref->getLoaderManager()->registerLoader($couchLoader, 'couchdb');
 ```

--- a/src/Dereferencer.php
+++ b/src/Dereferencer.php
@@ -2,10 +2,6 @@
 
 namespace League\JsonGuard;
 
-use League\JsonGuard\Loaders\CurlWebLoader;
-use League\JsonGuard\Loaders\FileGetContentsWebLoader;
-use League\JsonGuard\Loaders\FileLoader;
-
 /**
  * The Dereferencer resolves all external $refs and replaces
  * internal references with Reference objects.
@@ -13,17 +9,18 @@ use League\JsonGuard\Loaders\FileLoader;
 class Dereferencer
 {
     /**
-     * @var array
+     * @var LoaderManager
      */
-    private $loaders;
+    private $loaderManager;
 
     /**
      * Create a new Dereferencer.
+     *
+     * @param LoaderManager $loaderManager
      */
-    public function __construct()
+    public function __construct(LoaderManager $loaderManager = null)
     {
-        $this->registerFileLoader();
-        $this->registerDefaultWebLoaders();
+        $this->loaderManager = $loaderManager ?: new LoaderManager();
     }
 
     /**
@@ -48,66 +45,11 @@ class Dereferencer
     }
 
     /**
-     * Register a Loader for the given prefix.
-     *
-     * @param Loader $loader
-     * @param string $prefix
+     * @return LoaderManager
      */
-    public function registerLoader(Loader $loader, $prefix)
+    public function getLoaderManager()
     {
-        $this->loaders[$prefix] = $loader;
-    }
-
-    /**
-     * Get all registered loaders, keyed by the prefix they are registered to load schemas for.
-     *
-     * @return Loader[]
-     */
-    public function getLoaders()
-    {
-        return $this->loaders;
-    }
-
-    /**
-     * Get the loader for the given prefix.
-     *
-     * @param string $prefix
-     *
-     * @return Loader
-     * @throws \InvalidArgumentException
-     */
-    public function getLoader($prefix)
-    {
-        if (!array_key_exists($prefix, $this->loaders)) {
-            throw new \InvalidArgumentException(sprintf('A loader is not registered for the prefix "%s"', $prefix));
-        }
-
-        return $this->loaders[$prefix];
-    }
-
-    /**
-     * Register the default file loader.
-     */
-    private function registerFileLoader()
-    {
-        $this->loaders['file'] = new FileLoader();
-    }
-
-    /**
-     * Register the default web loaders.  If the curl extension is loaded,
-     * the CurlWebLoader will be used.  Otherwise the FileGetContentsWebLoader
-     * will be used.  You can override this by registering your own loader
-     * for the 'http' and 'https' protocols.
-     */
-    private function registerDefaultWebLoaders()
-    {
-        if (function_exists('curl_init')) {
-            $this->loaders['https'] = new CurlWebLoader('https://');
-            $this->loaders['http']  = new CurlWebLoader('http://');
-        } else {
-            $this->loaders['https'] = new FileGetContentsWebLoader('https://');
-            $this->loaders['http']  = new FileGetContentsWebLoader('http://');
-        }
+        return $this->loaderManager;
     }
 
     /**
@@ -242,7 +184,7 @@ class Dereferencer
     private function loadExternalRef($reference)
     {
         list($prefix, $path) = parse_external_ref($reference);
-        $loader = $this->getLoader($prefix);
+        $loader = $this->loaderManager->getLoader($prefix);
         $schema = $loader->load($path);
 
         return $schema;

--- a/src/LoaderManager.php
+++ b/src/LoaderManager.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace League\JsonGuard;
+
+use League\JsonGuard\Loaders\CurlWebLoader;
+use League\JsonGuard\Loaders\FileGetContentsWebLoader;
+use League\JsonGuard\Loaders\FileLoader;
+
+class LoaderManager
+{
+    /**
+     * @var Loader[]
+     */
+    private $loaders = [];
+
+    /**
+     * @param Loader[] $loaders
+     */
+    public function __construct(array $loaders = [])
+    {
+        if (empty($loaders)) {
+            $this->registerDefaultFileLoader();
+            $this->registerDefaultWebLoaders();
+            return;
+        }
+
+        foreach ($loaders as $prefix => $loader) {
+            $this->registerLoader($prefix, $loader);
+        }
+    }
+
+    /**
+     * Register a Loader for the given prefix.
+     *
+     * @param string $prefix
+     * @param Loader $loader
+     */
+    public function registerLoader($prefix, Loader $loader)
+    {
+        $this->loaders[$prefix] = $loader;
+    }
+
+    /**
+     * Get all registered loaders, keyed by the prefix they are registered to load schemas for.
+     *
+     * @return Loader[]
+     */
+    public function getLoaders()
+    {
+        return $this->loaders;
+    }
+
+    /**
+     * Get the loader for the given prefix.
+     *
+     * @param string $prefix
+     *
+     * @return Loader
+     * @throws \InvalidArgumentException
+     */
+    public function getLoader($prefix)
+    {
+        if (!$this->hasLoader($prefix)) {
+            throw new \InvalidArgumentException(sprintf('A loader is not registered for the prefix "%s"', $prefix));
+        }
+
+        return $this->loaders[$prefix];
+    }
+
+    /**
+     * @param string $prefix
+     *
+     * @return bool
+     */
+    public function hasLoader($prefix)
+    {
+        return isset($this->loaders[$prefix]);
+    }
+
+    /**
+     * Register the default file loader.
+     */
+    private function registerDefaultFileLoader()
+    {
+        $this->loaders['file'] = new FileLoader();
+    }
+
+    /**
+     * Register the default web loaders.  If the curl extension is loaded,
+     * the CurlWebLoader will be used.  Otherwise the FileGetContentsWebLoader
+     * will be used.  You can override this by registering your own loader
+     * for the 'http' and 'https' protocols.
+     */
+    private function registerDefaultWebLoaders()
+    {
+        if (function_exists('curl_init')) {
+            $this->loaders['https'] = new CurlWebLoader('https://');
+            $this->loaders['http']  = new CurlWebLoader('http://');
+        } else {
+            $this->loaders['https'] = new FileGetContentsWebLoader('https://');
+            $this->loaders['http']  = new FileGetContentsWebLoader('http://');
+        }
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -241,7 +241,7 @@ function resolve_uri($id, $parentScope)
 
 /**
  * Recursively iterates over each value in the schema passing them to the callback function.
- * If the callback function returns true, the value is returned into the result array, keyed by a JSON Pointer.
+ * If the callback function returns true the value is returned into the result array, keyed by a JSON Pointer.
  *
  * @param mixed    $schema
  * @param callable $callback

--- a/tests/DereferencerTest.php
+++ b/tests/DereferencerTest.php
@@ -3,7 +3,6 @@
 namespace League\JsonGuard\Test;
 
 use League\JsonGuard\Dereferencer;
-use League\JsonGuard\Loader;
 use League\JsonGuard\Loaders\ArrayLoader;
 use League\JsonGuard\Reference;
 
@@ -25,8 +24,8 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
             ['json-schema.org/draft-04/schema' => file_get_contents(__DIR__ . '/fixtures/draft4-schema.json')]
         );
         $deref  = new Dereferencer();
-        $deref->registerLoader($loader, 'http');
-        $deref->registerLoader($loader, 'https');
+        $deref->getLoaderManager()->registerLoader('http', $loader);
+        $deref->getLoaderManager()->registerLoader('https', $loader);
         $result = $deref->dereference('http://json-schema.org/draft-04/schema#');
         $this->assertSame($result->definitions->positiveIntegerDefault0, $result->properties->minItems->resolve());
     }
@@ -153,24 +152,5 @@ class DereferencerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Reference::class, $result->properties->rating);
         $this->assertFalse($result->properties->rating->additionalProperties);
         $this->assertFalse($result->properties->rating->properties->rating->additionalProperties);
-    }
-
-    public function testGetLoaders()
-    {
-        $deref = new Dereferencer();
-        $loaders = $deref->getLoaders();
-        $this->assertArrayHasKey('file', $loaders);
-        $this->assertInstanceOf(Loader::class, $loaders['file']);
-        $this->assertArrayHasKey('http', $loaders);
-        $this->assertInstanceOf(Loader::class, $loaders['http']);
-        $this->assertArrayHasKey('https', $loaders);
-        $this->assertInstanceOf(Loader::class, $loaders['https']);
-    }
-
-    public function testGetLoaderThrowsIfTheLoaderDoesNotExist()
-    {
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $deref = new Dereferencer();
-        $deref->dereference('couchdb://some-schema');
     }
 }

--- a/tests/LoaderManagerTest.php
+++ b/tests/LoaderManagerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace League\JsonGuard\Test;
+
+use League\JsonGuard\Loader;
+use League\JsonGuard\LoaderManager;
+use League\JsonGuard\Loaders\ArrayLoader;
+
+class LoaderManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetLoaders()
+    {
+        $manager = new LoaderManager();
+        $loaders = $manager->getLoaders();
+        $this->assertArrayHasKey('file', $loaders);
+        $this->assertInstanceOf(Loader::class, $loaders['file']);
+        $this->assertArrayHasKey('http', $loaders);
+        $this->assertInstanceOf(Loader::class, $loaders['http']);
+        $this->assertArrayHasKey('https', $loaders);
+        $this->assertInstanceOf(Loader::class, $loaders['https']);
+    }
+
+    public function testGetLoaderThrowsIfTheLoaderDoesNotExist()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $manager = new LoaderManager();
+        $manager->getLoader('couchdb');
+    }
+
+    public function testRegisterLoader()
+    {
+        $loader  = new ArrayLoader([]);
+        $manager = new LoaderManager();
+        $manager->registerLoader('http', $loader);
+        $this->assertSame($loader, $manager->getLoader('http'));
+    }
+
+    public function testDoesNotUseDefaultsIfLoadersAreSpecified()
+    {
+        $loaders  = [
+            'array' => new ArrayLoader([])
+        ];
+
+        $manager = new LoaderManager($loaders);
+
+        $this->assertFalse($manager->hasLoader('file'));
+        $this->assertFalse($manager->hasLoader('http'));
+        $this->assertFalse($manager->hasLoader('https'));
+        $this->assertTrue($manager->hasLoader('array'));
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -144,8 +144,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             new CurlWebLoader('http://')
         );
         $refResolver  = new Dereferencer();
-        $refResolver->registerLoader($httpLoader, 'http');
-        $refResolver->registerLoader($httpsLoader, 'https');
+        $refResolver->getLoaderManager()->registerLoader('http', $httpLoader);
+        $refResolver->getLoaderManager()->registerLoader('https', $httpsLoader);
 
         return $refResolver;
     }


### PR DESCRIPTION
This allows reusing the same set of loaders for bundling schemas
or inlining them.  This is a breaking change.