### PR TITLE
Use PSR-11 for rulesets & add a set method to the default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "sabre/uri": "^1.1"
+        "sabre/uri": "^1.1",
+        "psr/container": "^1.0"
     },
     "suggest": {
         "ext-bcmath": "Required to properly check constraints for numbers larger than PHP_INT_MAX."

--- a/docs/validation/extending.md
+++ b/docs/validation/extending.md
@@ -10,7 +10,7 @@ You may need to validate JSON with constraints beyond what is defined in Draft4 
 
 ## Rulesets
 
-Internally JSON Guard uses [rule sets](https://github.com/league/json-guard/blob/master/src/RuleSet.php), which are composed of [constraints](https://github.com/league/json-guard/tree/master/src/Constraints).  By default the Draft4 rule set is used, which corresponds to Draft 4 of the JSON Schema specification.  You can easily provide your own rule set by passing it as a constructor parameter.
+Internally JSON Guard uses rule sets, which are composed of [constraints](https://github.com/league/json-guard/tree/master/src/Constraints).  The rule set is just a [PSR-11 container](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md) of constraints identified by the validation keyword.  By default the Draft4 rule set is used, which corresponds to Draft 4 of the JSON Schema specification.  You can easily provide your own rule set by passing it as a constructor parameter.
 
 ```php
 <?php

--- a/src/Exceptions/ConstraintException.php
+++ b/src/Exceptions/ConstraintException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\JsonGuard\Exceptions;
+
+use Psr\Container\ContainerExceptionInterface;
+
+class ConstraintException extends \Exception implements ContainerExceptionInterface
+{
+    /**
+     * @param string     $rule
+     * @param \Exception $previous
+     *
+     * @return ConstraintException
+     */
+    public static function forRule($rule, \Exception $previous)
+    {
+        return new static(sprintf('An exception occurred while building %s.', $rule), 0, $previous);
+    }
+}

--- a/src/Exceptions/ConstraintNotFoundException.php
+++ b/src/Exceptions/ConstraintNotFoundException.php
@@ -2,7 +2,9 @@
 
 namespace League\JsonGuard\Exceptions;
 
-class ConstraintNotFoundException extends \Exception
+use Psr\Container\NotFoundExceptionInterface;
+
+class ConstraintNotFoundException extends \Exception implements NotFoundExceptionInterface
 {
     public static function forRule($rule)
     {

--- a/src/RuleSets/DraftFour.php
+++ b/src/RuleSets/DraftFour.php
@@ -27,16 +27,17 @@ use League\JsonGuard\Constraints\Properties;
 use League\JsonGuard\Constraints\Required;
 use League\JsonGuard\Constraints\Type;
 use League\JsonGuard\Constraints\UniqueItems;
-use League\JsonGuard\Exceptions\ConstraintNotFoundException;
-use League\JsonGuard\RuleSet;
+use Psr\Container\ContainerInterface;
 
 /**
  * The default rule set for JSON Schema Draft 4.
  * @see http://tools.ietf.org/html/draft-zyp-json-schema-04
  * @see  https://tools.ietf.org/html/draft-fge-json-schema-validation-00
  */
-class DraftFour implements RuleSet
+class DraftFour implements ContainerInterface
 {
+    use RuleSetTrait;
+
     protected $rules = [
         'additionalItems'      => AdditionalItems::class,
         'additionalProperties' => AdditionalProperties::class,
@@ -68,20 +69,16 @@ class DraftFour implements RuleSet
     /**
      * {@inheritdoc}
      */
-    public function has($rule)
+    protected function rules()
     {
-        return array_key_exists($rule, $this->rules);
+        return $this->rules;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getConstraint($rule)
+    protected function setRule($id, $constraint)
     {
-        if (!$this->has($rule)) {
-            throw ConstraintNotFoundException::forRule($rule);
-        }
-
-        return new $this->rules[$rule];
+        $this->rules[$id] = $constraint;
     }
 }

--- a/src/RuleSets/RuleSetTrait.php
+++ b/src/RuleSets/RuleSetTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace League\JsonGuard\RuleSets;
+
+use League\JsonGuard\Exceptions\ConstraintException;
+use League\JsonGuard\Exceptions\ConstraintNotFoundException;
+
+trait RuleSetTrait
+{
+    /**
+     * @return array
+     */
+    abstract protected function rules();
+
+    /**
+     * @param string          $id
+     * @param string|\Closure $constraint
+     *
+     * @return void
+     */
+    abstract protected function setRule($id, $constraint);
+
+    /**
+     * @param string          $id
+     * @param string|\Closure $constraint
+     */
+    public function set($id, $constraint)
+    {
+        if (!is_string($constraint) && !$constraint instanceof \Closure) {
+            throw new \InvalidArgumentException(sprintf('Expected a string or Closure, got %s', gettype($constraint)));
+        }
+        $this->setRule($id, $constraint);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return array_key_exists($id, $this->rules());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        if (!$this->has($id)) {
+            throw ConstraintNotFoundException::forRule($id);
+        }
+
+        $concrete = $this->rules()[$id];
+
+        try {
+            return is_string($concrete) ? new $concrete() : $concrete();
+        } catch (\Exception $e) {
+            throw ConstraintException::forRule($id, $e);
+        }
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -2,9 +2,11 @@
 
 namespace League\JsonGuard;
 
+use League\JsonGuard\Constraints\Constraint;
 use League\JsonGuard\Exceptions\MaximumDepthExceededException;
 use League\JsonGuard\RuleSets\DraftFour;
 use League\JsonReference\Reference;
+use Psr\Container\ContainerInterface;
 
 class Validator
 {
@@ -49,7 +51,7 @@ class Validator
     private $formatExtensions = [];
 
     /**
-     * @var \League\JsonGuard\RuleSet
+     * @var \Psr\Container\ContainerInterface
      */
     private $ruleSet;
 
@@ -59,11 +61,11 @@ class Validator
     private $hasValidated;
 
     /**
-     * @param mixed        $data
-     * @param object       $schema
-     * @param RuleSet|null $ruleSet
+     * @param mixed                   $data
+     * @param object                  $schema
+     * @param ContainerInterface|null $ruleSet
      */
-    public function __construct($data, $schema, RuleSet $ruleSet = null)
+    public function __construct($data, $schema, ContainerInterface $ruleSet = null)
     {
         if (!is_object($schema)) {
             throw new \InvalidArgumentException(
@@ -232,7 +234,8 @@ class Validator
             return $this->validateCustomFormat($parameter);
         }
 
-        $constraint = $this->ruleSet->getConstraint($rule);
+        /** @var Constraint $constraint */
+        $constraint = $this->ruleSet->get($rule);
 
         return $constraint->validate($this->data, $parameter, $this);
     }

--- a/tests/RuleSets/DraftFourRuleSetTest.php
+++ b/tests/RuleSets/DraftFourRuleSetTest.php
@@ -18,6 +18,6 @@ class DraftFourRuleSetTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(ConstraintNotFoundException::class);
         $ruleSet = new DraftFour();
-        $ruleSet->getConstraint('nonExistent');
+        $ruleSet->get('nonExistent');
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -272,7 +272,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $schema = json_decode('{"properties": { "foo": {"type": "string", "emoji": true} } }');
         $data = json_decode('{ "foo": ":)" }');
 
-        $ruleSet = new CustomRulesetStub();
+        $ruleSet = new DraftFour();
+        $ruleSet->set('emoji', EmojiConstraint::class);
         $v = new Validator($data, $schema, $ruleSet);
         $this->assertTrue($v->passes());
 
@@ -301,31 +302,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         ], $schema);
 
         $this->assertTrue($validator->fails());
-    }
-}
-
-class CustomRulesetStub extends DraftFour
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function has($rule)
-    {
-        if ($rule === 'emoji') {
-            return true;
-        }
-        return parent::has($rule);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConstraint($rule)
-    {
-        if ($rule === 'emoji') {
-            return new EmojiConstraint();
-        }
-        return parent::getConstraint($rule);
     }
 }
 


### PR DESCRIPTION
I realized the ruleset interface is almost exactly the same as PSR-11.  Using PSR-11 means you can use any container you want to build rulesets.  This should make it easier to build rulesets with more complex constructor dependencies, cache instantiation, or delegate lookups to make overriding rules easier.