### PR TITLE
Improve multibyte string length validation

### DIFF
--- a/src/Constraints/MaxLength.php
+++ b/src/Constraints/MaxLength.php
@@ -12,6 +12,20 @@ class MaxLength implements Constraint
     const KEYWORD = 'maxLength';
 
     /**
+     * @var string
+     */
+    private $charset;
+
+    /**
+     * @param string $charset
+     */
+    public function __construct($charset = 'UTF-8')
+    {
+        $this->charset = $charset;
+    }
+
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, $parameter, Validator $validator)
@@ -19,7 +33,7 @@ class MaxLength implements Constraint
         Assert::type($parameter, 'number', self::KEYWORD, $validator->getPointer());
         Assert::nonNegative($parameter, self::KEYWORD, $validator->getPointer());
 
-        if (!is_string($value) || JsonGuard\strlen($value) <= $parameter) {
+        if (!is_string($value) || JsonGuard\strlen($value, $this->charset) <= $parameter) {
             return null;
         }
 

--- a/src/Constraints/MinLength.php
+++ b/src/Constraints/MinLength.php
@@ -12,6 +12,19 @@ class MinLength implements Constraint
     const KEYWORD = 'minLength';
 
     /**
+     * @var string
+     */
+    private $charset;
+
+    /**
+     * @param string $charset
+     */
+    public function __construct($charset = 'UTF-8')
+    {
+        $this->charset = $charset;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, $parameter, Validator $validator)
@@ -19,7 +32,7 @@ class MinLength implements Constraint
         Assert::type($parameter, 'number', self::KEYWORD, $validator->getPointer());
         Assert::nonNegative($parameter, self::KEYWORD, $validator->getPointer());
 
-        if (!is_string($value) || JsonGuard\strlen($value) >= $parameter) {
+        if (!is_string($value) || JsonGuard\strlen($value, $this->charset) >= $parameter) {
             return null;
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,17 +3,23 @@
 namespace League\JsonGuard;
 
 /**
- * @param $string
+ * @param string $string
+ * @param string $charset
+ *
  * @return int
  */
-function strlen($string)
+function strlen($string, $charset = 'UTF-8')
 {
-    if (extension_loaded('intl')) {
-        return grapheme_strlen($string);
+    if (function_exists('iconv_strlen')) {
+        return iconv_strlen($string, $charset);
     }
 
-    if (extension_loaded('mbstring')) {
-        return mb_strlen($string, mb_detect_encoding($string));
+    if (function_exists('mb_strlen')) {
+        return mb_strlen($string, $charset);
+    }
+
+    if (function_exists('utf8_decode') && $charset === 'UTF-8') {
+        $string = utf8_decode($string);
     }
 
     return \strlen($string);
@@ -79,7 +85,7 @@ function delimit_pattern($pattern)
  */
 function is_json_integer($value)
 {
-    if (is_string($value) && strlen($value) && $value[0] === '-') {
+    if (is_string($value) && \strlen($value) && $value[0] === '-') {
         $value = substr($value, 1);
     }
 

--- a/tests/Constraints/MinLengthTest.php
+++ b/tests/Constraints/MinLengthTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\JsonGuard\Test\Constraints;
+
+use League\JsonGuard\Constraints\MinLength;
+use League\JsonGuard\ValidationError;
+use League\JsonGuard\Validator;
+
+class MinLengthTest extends \PHPUnit_Framework_TestCase
+{
+    function test_it_validates_multibyte_string_length_correctly()
+    {
+        $value      = '按时间先后进行排序';
+        $constraint = new MinLength();
+        $validator  = new Validator((object) [], (object) []);
+        $this->assertNull($constraint->validate($value, 9, $validator));
+        $this->assertInstanceOf(ValidationError::class, $constraint->validate($value, 10, $validator));
+    }
+}


### PR DESCRIPTION
- Drop grapheme_strlen [since it shouldn't really be used](https://github.com/symfony/symfony/issues/13491)
- Allow specifying the charset
- Try to utf8_decode as a fallback.