### PR TITLE
Emphasize return type in documentation detail.

### DIFF
--- a/docs/validation/overview.md
+++ b/docs/validation/overview.md
@@ -10,7 +10,7 @@ title: Overview
 
 Validators are created by instantiating a new instance of the `Validator` class.  The first argument is the data under validation.  The second argument is the schema that should be applied to the data.
 
-The JSON data we are validating needs to be the object resulting from a `json_decode` call.  The validator **will not work** with the array returned from `json_decode($data, true)`.  For example:
+The JSON data we are validating needs to be the **object** resulting from a `json_decode` call.  The validator **will not work** with the **array** returned from `json_decode($data, true)`.  For example:
 
 ```php
 <?php


### PR DESCRIPTION
I think this detail is easily overlooked by developers unfamiliar with the fact PHP's `json_decode()` function can return an object or array depending on the boolean argument passed in the second parameter. Making the return types bold in documentation somehow makes me feel better.