### PR TITLE
A string composed of many digits can be a string

### DIFF
--- a/src/Constraint/DraftFour/Type.php
+++ b/src/Constraint/DraftFour/Type.php
@@ -13,6 +13,26 @@ final class Type implements ConstraintInterface
     const KEYWORD = 'type';
 
     /**
+     * Whether examples like 98249283749234923498293171823948729348710298301928331
+     * and "98249283749234923498293171823948729348710298301928331" are valid strings.
+     */
+    const BIGINT_MODE_STRING_VALID = 1;
+    const BIGINT_MODE_STRING_INVALID = 2;
+
+    /**
+     * @var int
+     */
+    private $bigintMode = 0;
+
+    /**
+     * @param int $bigintMode
+     */
+    public function __construct($bigintMode = self::BIGINT_MODE_STRING_INVALID)
+    {
+        $this->setBigintMode($bigintMode);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, $type, Validator $validator)
@@ -52,7 +72,8 @@ final class Type implements ConstraintInterface
                             // Make sure the string isn't actually a number that was too large
                             // to be cast to an int on this platform.  This will only happen if
                             // you decode JSON with the JSON_BIGINT_AS_STRING option.
-                            if (!(ctype_digit($value) && bccomp($value, PHP_INT_MAX) === 1)) {
+                            if (self::BIGINT_MODE_STRING_VALID === $this->bigintMode
+                                || !(ctype_digit($value) && bccomp($value, PHP_INT_MAX) === 1)) {
                                 return true;
                             }
                         }
@@ -62,6 +83,28 @@ final class Type implements ConstraintInterface
                     $validator
                 );
         }
+    }
+
+    /**
+     * @param int|null $bigintMode
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setBigintMode($bigintMode = self::BIGINT_MODE_STRING_INVALID)
+    {
+        if (!in_array($bigintMode, [self::BIGINT_MODE_STRING_VALID, self::BIGINT_MODE_STRING_INVALID])) {
+            throw new \InvalidArgumentException('Please use one of the bigint mode constants.');
+        }
+
+        $this->bigintMode = $bigintMode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBigintMode()
+    {
+        return $this->bigintMode;
     }
 
     /**

--- a/tests/Constraint/TypeTest.php
+++ b/tests/Constraint/TypeTest.php
@@ -16,4 +16,22 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(ValidationError::class, $error);
     }
+
+    function test_bigint_mode_valid()
+    {
+        $type = new Type(Type::BIGINT_MODE_STRING_VALID);
+
+        $error = $type->validate('98249283749234923498293171823948729348710298301928331', 'string', new Validator([], new \stdClass()));
+
+        $this->assertNull($error);
+    }
+
+    function test_bigint_mode_invalid()
+    {
+        $type = new Type(Type::BIGINT_MODE_STRING_INVALID);
+
+        $error = $type->validate('98249283749234923498293171823948729348710298301928331', 'string', new Validator([], new \stdClass()));
+
+        $this->assertInstanceOf(ValidationError::class, $error);
+    }
 }


### PR DESCRIPTION
Let's discuss the string of digits versus big int thing.

The json schema test cases prescribe that `98249283749234923498293171823948729348710298301928331` should be interpreted as a number and implicitly that `"x8249283749234923498293171823948729348710298301928331"` is a string (note the leading '9' has been replaced by an 'x' and that it actually is a string). So far so good.

Then there is our big friend `JSON_BIGINT_AS_STRING`. Using it results in a case where the validator actually cannot tell if someone submitted the number `98249283749234923498293171823948729348710298301928331` or the string `"98249283749234923498293171823948729348710298301928331"`. That's where the hassle begins.

The [test suite](https://github.com/json-schema/JSON-Schema-Test-Suite) also prescribes in an optional test that a big int is not a string. Sounds logical. However, as I just described, PHP cannot tell the difference anymore between if the value was submitted as a string or that is has been submitted as an integer after decoding it with `JSON_BIGINT_AS_STRING`.
The choice made so far has been to check if a string is composed out of digits only and check if it represents a value bigger then `PHP_INT_MAX`. However, this results in the problem that no strings can be validated as string if they happen to be composed out of a lot of digits only.
I think that's wrong, because certain strings actually can be just strings and should be able to validate as such.

I also think that there are several ways to handle this case better of which I'm describing two below.
1. The first is the staring point of this pr. It simply lets lets the big number validate as a valid string too (in addition to validating it as a valid integer), and adds line in the tests to convert the 'big int is not a string' test into a 'big int is a string' test.
2. The second is a bit more bulky but maybe more correct: adding an option (constructor and/or setter) to the Type constraint to let the end user decide which mode should be used. Something like `$validator->getRuleSet()->get('type')->setBigIntMode(Type::BIG_INT_AS_STRING);`, where it would validate a big int and a string of digits as strings.

Let me know your thoughts! :)