### PR TITLE
Fix date-time validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+## Fixed
+
+* Fixed many instances of the date-time validation rejecting valid values and allowing invalid values.
+
 ## 1.0.1 - 2017-05-03
 
 ## Fixed

--- a/src/Constraint/DraftFour/Format.php
+++ b/src/Constraint/DraftFour/Format.php
@@ -12,11 +12,17 @@ final class Format implements ConstraintInterface
 {
     const KEYWORD = 'format';
 
-    // @codingStandardsIgnoreStart
-    // @see https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/datatypes.html#dateTime-lexical-mapping
-    const DATE_TIME_PATTERN = '/^-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$/';
-    // @codingStandardsIgnoreEnd
+    /**
+     * @see https://tools.ietf.org/html/rfc3339#section-5.6
+     */
+    const DATE_TIME_PATTERN =
+        '/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])' . 'T' .
+        '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
+        '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/i';
 
+    /**
+     * @internal
+     */
     const HOST_NAME_PATTERN = '/^[_a-z]+\.([_a-z]+\.?)+$/i';
 
     /**

--- a/tests/Constraint/FormatTest.php
+++ b/tests/Constraint/FormatTest.php
@@ -33,8 +33,9 @@ class FormatTest extends \PHPUnit_Framework_TestCase
             ['9999-99-9999999999'],
             ['9999-99-99'],
             ['2222-11-11abcderf'],
-            ['1963-06-19t08:30:06.283185Z'],
             ['1963-06-19'],
+            ['-1990-12-31T15:59:60-08:00'], // leading -
+            ['1990-12-31T23:59:61Z'], // seconds > 60
         ];
     }
 
@@ -45,5 +46,28 @@ class FormatTest extends \PHPUnit_Framework_TestCase
     {
         $result = (new Format())->validate($value, 'date-time', new Validator([], new \stdClass()));
         $this->assertInstanceOf(ValidationError::class, $result);
+    }
+
+    public function validDateTimeValues()
+    {
+        return [
+            ['1963-06-19T08:30:06Z'], // without fractional seconds
+            ['1985-04-12T23:20:50.52Z'], // with fractional seconds
+            ['1990-12-31T23:59:50+01:01'], // positive offset
+            ['1990-12-31T23:59:50-01:01'], // negative offset
+            ['1990-12-31T23:59:50+23:00'], // the offset can be any hour
+            ['1990-12-31T23:59:60Z'], // leap second
+            ['0000-06-19T08:30:06Z'], // literally any 4 digits can be a year
+            ['1963-06-19t08:30:06.283185z'], // lowercase t and z
+        ];
+    }
+
+    /**
+     * @dataProvider validDateTimeValues
+     */
+    function test_date_time_passes_for_valid_iso8601_date_time($value)
+    {
+        $result = (new Format())->validate($value, 'date-time', new Validator([], new \stdClass()));
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
There were a lot of bugs in the date-time regex so I set down and rewrote it from scratch to match the RFC3339 ABNF syntax exactly.

References:

http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3.1
https://tools.ietf.org/html/rfc3339#section-5.6