### PR TITLE
Possibility to fail if string format is unknown

### DIFF
--- a/src/Constraint/DraftFour/Format.php
+++ b/src/Constraint/DraftFour/Format.php
@@ -7,6 +7,7 @@ use League\JsonGuard\Constraint\DraftFour\Format\FormatExtensionInterface;
 use League\JsonGuard\ConstraintInterface;
 use League\JsonGuard\Validator;
 use function League\JsonGuard\error;
+use League\JsonGuard\Exception\InvalidSchemaException;
 
 final class Format implements ConstraintInterface
 {
@@ -26,20 +27,33 @@ final class Format implements ConstraintInterface
     const HOST_NAME_PATTERN = '/^[_a-z]+\.([_a-z]+\.?)+$/i';
 
     /**
+     * @var string[]
+     */
+    const KNWON_FORMATS = ['date-time', 'uri', 'email', 'ipv4', 'ipv6','hostname'];
+
+    /**
      * @var \League\JsonGuard\Constraint\DraftFour\Format\FormatExtensionInterface[]
      */
     private $extensions = [];
 
     /**
+     * @var bool
+     */
+    private $ignoreUnknownFormats = true;
+
+    /**
      * Any custom format extensions to use, indexed by the format name.
      *
      * @param array \League\JsonGuard\Constraint\DraftFour\Format\FormatExtensionInterface[]
+     * @param bool
      */
-    public function __construct(array $extensions = [])
+    public function __construct(array $extensions = [], $ignoreUnknownFormats = true)
     {
         foreach ($extensions as $format => $extension) {
             $this->addExtension($format, $extension);
         }
+
+        $this->ignoreUnknownFormats = $ignoreUnknownFormats;
     }
 
     /**
@@ -51,6 +65,16 @@ final class Format implements ConstraintInterface
     public function addExtension($format, FormatExtensionInterface $extension)
     {
         $this->extensions[$format] = $extension;
+    }
+
+    /**
+     * Define if unknown formats shall be ignored
+     *
+     * @param boolean
+     */
+    public function setIgnoreUnknownFormats($ignoreUnknownFormats)
+    {
+        $this->ignoreUnknownFormats = $ignoreUnknownFormats;
     }
 
     /**
@@ -105,6 +129,15 @@ final class Format implements ConstraintInterface
                     self::HOST_NAME_PATTERN,
                     $validator
                 );
+            default:
+                if (!$this->ignoreUnknownFormats) {
+                    throw InvalidSchemaException::invalidParameter(
+                        $parameter,
+                        array_merge(self::KNWON_FORMATS, array_keys($this->extensions)),
+                        self::KEYWORD,
+                        $validator->getSchemaPath()
+                    );
+                }
         }
     }
 
@@ -114,7 +147,6 @@ final class Format implements ConstraintInterface
      * @param \League\JsonGuard\Validator $validator
      *
      * @return \League\JsonGuard\ValidationError|null
-     *
      */
     private static function validateRegex($value, $pattern, Validator $validator)
     {
@@ -132,7 +164,6 @@ final class Format implements ConstraintInterface
      * @param \League\JsonGuard\Validator $validator
      *
      * @return \League\JsonGuard\ValidationError|null
-     *
      */
     private static function validateFilter($value, $filter, $options, Validator $validator)
     {

--- a/src/Exception/InvalidSchemaException.php
+++ b/src/Exception/InvalidSchemaException.php
@@ -47,6 +47,25 @@ final class InvalidSchemaException extends \RuntimeException
     }
 
     /**
+     * @param string $actualParameter
+     * @param array  $allowedParameter
+     * @param string $keyword
+     * @param string $pointer
+     *
+     * @return \League\JsonGuard\Exception\InvalidSchemaException
+     */
+    public static function invalidParameter($actualParameter, array $allowedParameter, $keyword, $pointer)
+    {
+        $message = sprintf(
+            'Value is "%s" but must be one of: "%s"',
+            $actualParameter,
+            implode(', ', $allowedParameter)
+        );
+
+        return new self($message, $keyword, $pointer);
+    }
+
+    /**
      * @param integer $value
      * @param string  $keyword
      * @param string  $pointer

--- a/tests/Constraint/FormatTest.php
+++ b/tests/Constraint/FormatTest.php
@@ -5,8 +5,26 @@ namespace League\JsonGuard\Test\Constraint;
 use League\JsonGuard\Constraint\DraftFour\Format;
 use League\JsonGuard\ValidationError;
 use League\JsonGuard\Validator;
+use PHPUnit\Framework\TestCase;
+use League\JsonGuard\Constraint\DraftFour\Format\FormatExtensionInterface;
+use function League\JsonGuard\error;
+use League\JsonGuard\Exception\InvalidSchemaException;
 
-class FormatTest extends \PHPUnit_Framework_TestCase
+class FormatUuid implements FormatExtensionInterface
+{
+    public function validate($value, Validator $validator)
+    {
+        $pattern = '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+        
+        if (!is_string($value) || preg_match($pattern, $value) === 1) {
+            return null;
+        }
+
+        return error('The value {data} must match the format {parameter}.', $validator);
+    }
+}
+
+class FormatTest extends TestCase
 {
     public function invalidFormatValues()
     {
@@ -68,6 +86,69 @@ class FormatTest extends \PHPUnit_Framework_TestCase
     function test_date_time_passes_for_valid_iso8601_date_time($value)
     {
         $result = (new Format())->validate($value, 'date-time', new Validator([], new \stdClass()));
+        $this->assertNull($result);
+    }
+    
+    public function validUuidValues()
+    {
+        return [
+            ['6ac84682-ac2f-11e7-8f1a-0800200c9a66'],
+            ['e1eae6a3-2584-3e90-80bf-ca0ab5dd527a'],
+            ['274ec8c0-cda9-44f5-8962-8e21052a24a9'],
+            ['acd9d304-3432-59d2-a14f-701c96fe0c10']
+        ];
+    }
+    
+    /**
+     * @dataProvider validUuidValues
+     */
+    function test_if_ignore_unknown_formats_is_true_by_default($value)
+    {
+        $result = (new Format())->validate($value, 'uuid', new Validator([], new \stdClass()));
+        $this->assertNull($result);
+    }
+    
+    /**
+     * @dataProvider validUuidValues
+     */
+    function test_unknown_format_passes_if_ignore_unknown_formats_is_true($value)
+    {
+        $format = new Format();
+        $format->setIgnoreUnknownFormats(true);
+        $result = $format->validate($value, 'uuid', new Validator([], new \stdClass()));
+        $this->assertNull($result);
+    }
+    
+    /**
+     * @dataProvider validUuidValues
+     */
+    function test_unknown_format_does_not_pass_if_ignore_unknown_formats_is_false_by_constructor($value)
+    {
+        $this->setExpectedException(InvalidSchemaException::class);
+        $format = new Format([], false);
+        $result = $format->validate($value, 'uuid', new Validator([], new \stdClass()));
+        $this->assertInstanceOf(ValidationError::class, $result);
+    }
+    
+    /**
+     * @dataProvider validUuidValues
+     */
+    function test_unknown_format_does_not_pass_if_ignore_unknown_formats_is_false_by_setter($value)
+    {
+        $this->setExpectedException(InvalidSchemaException::class);
+        $format = new Format();
+        $format->setIgnoreUnknownFormats(false);
+        $result = $format->validate($value, 'uuid', new Validator([], new \stdClass()));
+        $this->assertInstanceOf(ValidationError::class, $result);
+    }
+    
+    /**
+     * @dataProvider validUuidValues
+     */
+    function test_user_defined_format_passes_if_implemented($value)
+    {
+        $format = new Format(['uuid' => new FormatUuid()], false);
+        $result = $format->validate($value, 'uuid', new Validator([], new \stdClass()));
         $this->assertNull($result);
     }
 }

--- a/tests/Exception/InvalidSchemaExceptionTest.php
+++ b/tests/Exception/InvalidSchemaExceptionTest.php
@@ -26,6 +26,20 @@ class InvalidSchemaExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($keyword, $e->getKeyword());
         $this->assertSame($pointer, $e->getPointer());
     }
+    
+    function test_invalid_parameter_constructor()
+    {
+        $e = InvalidSchemaException::invalidParameter(
+            'uuid',
+            ['ipv4'],
+            $keyword = 'minimum',
+            $pointer = '/properties/likes'
+        );
+
+        $this->assertSame('Value is "uuid" but must be one of: "ipv4"', $e->getMessage());
+        $this->assertSame($keyword, $e->getKeyword());
+        $this->assertSame($pointer, $e->getPointer());
+    }
 
     function test_negative_value_constructor()
     {


### PR DESCRIPTION
For security reasons I want the validation to fail in case that there are unknown attributes.

The spec says "If the type of the instance to validate is not in this set, validation for this format attribute and instance SHOULD succeed", hence I left the default behavior unchanged. 

I added the possibility to add a default handler if the format attribute is unknown.