### PR TITLE
Possibility fail if constraint is unknown

### DIFF
--- a/docs/validation/extending.md
+++ b/docs/validation/extending.md
@@ -22,6 +22,23 @@ $ruleset = new CustomRuleset();
 $validator = new Validator($data, $schema, $ruleset);
 ```
 
+## Unknown Constraints
+
+The default behavior is to ignore unknown constraints. You may want to handle such constraints differently.
+
+```php
+<?php
+
+$data    = json_decode('{ "id": "json-guard.dev/schema#" }');
+$schema  = json_decode('{ "properties": { "id": { "type": "string", "format": "uri" } } }');
+$ruleset = new CustomRuleset();
+$ignoreUnknownConstraints = false;
+
+$validator = new Validator($data, $schema, $ruleset, $ignoreUnknownConstraints);
+```
+
+This will cause a `ConstraintNotFoundException` to be thrown in case that the constraint could not be found.
+
 ## Format Extensions
 
 JSON Schema allows defining formats like `ipv4` that strings will be validated against.  You can extend the validator with your own formats.

--- a/src/Constraint/DraftFour/NullValidator.php
+++ b/src/Constraint/DraftFour/NullValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\JsonGuard\Constraint\DraftFour;
+
+use League\JsonGuard\Assert;
+use League\JsonGuard\ConstraintInterface;
+use League\JsonGuard\Validator;
+use function League\JsonGuard\error;
+
+final class NullValidator implements ConstraintInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, $parameter, Validator $validator)
+    {
+        return null;
+    }
+}

--- a/src/RuleSet/DraftFour.php
+++ b/src/RuleSet/DraftFour.php
@@ -29,6 +29,7 @@ use League\JsonGuard\Constraint\DraftFour\Properties;
 use League\JsonGuard\Constraint\DraftFour\Required;
 use League\JsonGuard\Constraint\DraftFour\Type;
 use League\JsonGuard\Constraint\DraftFour\UniqueItems;
+use League\JsonGuard\Constraint\DraftFour\NullValidator;
 
 /**
  * The default rule set for JSON Schema Draft 4.
@@ -65,6 +66,14 @@ final class DraftFour extends RuleSetContainer
         Required::KEYWORD             => Required::class,
         Type::KEYWORD                 => Type::class,
         UniqueItems::KEYWORD          => UniqueItems::class,
+        '$schema'                     => NullValidator::class,
+
+        // Metadata
+        'definitions'                 => NullValidator::class,
+        'title'                       => NullValidator::class,
+        'description'                 => NullValidator::class,
+        'default'                     => NullValidator::class,
+        'examples'                    => NullValidator::class
     ];
 
     public function __construct(array $rules = [])

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -6,6 +6,7 @@ use League\JsonGuard\Exception\MaximumDepthExceededException;
 use League\JsonGuard\RuleSet\DraftFour;
 use League\JsonReference\Reference;
 use Psr\Container\ContainerInterface;
+use \League\JsonGuard\Exception\InvalidSchemaException;
 
 final class Validator
 {
@@ -70,11 +71,17 @@ final class Validator
     private $currentParameter;
 
     /**
+     * @var bool
+     */
+    private $ignoreUnknownConstraints = true;
+
+    /**
      * @param mixed                   $data
      * @param object                  $schema
      * @param ContainerInterface|null $ruleSet
+     * @param bool                    $ignoreUnknownConstraints
      */
-    public function __construct($data, $schema, ContainerInterface $ruleSet = null)
+    public function __construct($data, $schema, ContainerInterface $ruleSet = null, $ignoreUnknownConstraints = true)
     {
         if (!is_object($schema)) {
             throw new \InvalidArgumentException(
@@ -89,6 +96,17 @@ final class Validator
         $this->data    = $data;
         $this->schema  = $schema;
         $this->ruleSet = $ruleSet ?: new DraftFour();
+        $this->ignoreUnknownConstraints = $ignoreUnknownConstraints;
+    }
+
+    /**
+     * Define if unknown constraints shall be ignored
+     *
+     * @param boolean
+     */
+    public function setIgnoreUnknownConstraints($ignoreUnknownConstraints)
+    {
+        $this->ignoreUnknownConstraints = $ignoreUnknownConstraints;
     }
 
     /**
@@ -267,7 +285,7 @@ final class Validator
      */
     private function validateRule($keyword, $parameter)
     {
-        if (!$this->ruleSet->has($keyword)) {
+        if ($this->ignoreUnknownConstraints && !$this->ruleSet->has($keyword)) {
             return null;
         }
 

--- a/tests/fixtures/custom_constraint.json
+++ b/tests/fixtures/custom_constraint.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "name": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "sub-product": { "$ref": "schema.json" }
+  },
+  "required": ["id", "name", "price"],
+  "x-custom": "custom"
+}


### PR DESCRIPTION
Hi,

For security reasons I want the validation to fail in case that there are unknown constraints. I added the option to the Validator to fail in such cases with `ConstraintNotFoundException` (via constructor or setter).

I added a null-Validator for
- $schema
- definitions
- title
- description
- default
- examples

These keywords are defined in the standard but not (yet) validate. The null-Validator will prevent  `ConstraintNotFoundException`s for these keywords.