### PR TITLE
Added CVV format

### DIFF
--- a/src/Constraint/DraftFour/Format.php
+++ b/src/Constraint/DraftFour/Format.php
@@ -28,10 +28,15 @@ final class Format implements ConstraintInterface
 
     /**
      * @internal
+     */
+    const CVV_PATTERN = '/^[0-9]{3,4}$/i';
+
+    /**
+     * @internal
      *
      * @var string[]
      */
-    const KNOWN_FORMATS = ['date-time', 'uri', 'email', 'ipv4', 'ipv6','hostname'];
+    const KNOWN_FORMATS = ['date-time', 'uri', 'email', 'ipv4', 'ipv6','hostname', 'cvv'];
 
     /**
      * @var \League\JsonGuard\Constraint\DraftFour\Format\FormatExtensionInterface[]
@@ -129,6 +134,12 @@ final class Format implements ConstraintInterface
                 return self::validateRegex(
                     $value,
                     self::HOST_NAME_PATTERN,
+                    $validator
+                );
+            case 'cvv':
+                return self::validateRegex(
+                    $value,
+                    self::CVV_PATTERN,
                     $validator
                 );
             default:

--- a/tests/Constraint/FormatTest.php
+++ b/tests/Constraint/FormatTest.php
@@ -18,6 +18,7 @@ class FormatTest extends TestCase
             [[], 'date-time'],
             [new \stdClass(), 'uri'],
             [1234, 'email'],
+            [123, 'cvv'],
         ];
     }
 
@@ -136,6 +137,42 @@ class FormatTest extends TestCase
         $format = new Format(['uuid' => new FormatUuid()], false);
         $result = $format->validate($value, 'uuid', new Validator([], new \stdClass()));
         $this->assertNull($result);
+    }
+
+    public function validCvvValues()
+    {
+        return [
+            ['123'],
+            ['009'],
+            ['0123'],
+        ];
+    }
+
+    /**
+     * @dataProvider validCvvValues
+     */
+    function test_cvv_passes_for_valid_cvv_options($value)
+    {
+        $result = (new Format())->validate($value, 'cvv', new Validator([], new \stdClass()));
+        $this->assertNull($result);
+    }
+
+    public function invalidCvvValues()
+    {
+        return [
+            ['23'],
+            ['09230'],
+            ['1234567'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidCvvValues
+     */
+    function test_cvv_does_not_pass_for_invalid_cvv_options($value)
+    {
+        $result = (new Format())->validate($value, 'cvv', new Validator([], new \stdClass()));
+        $this->assertInstanceOf(ValidationError::class, $result);
     }
 }
 


### PR DESCRIPTION
The Card Verification Value (CVV) is an extra code printed on your debit or credit card.
CVV for Visa, MasterCard and Diners is the final three digits of the number printed on the signature strip on the back of your card.
CVV for American Express appears as a separate 4-digit code printed on the front of your card.

This PR extends the format class to include a custom validator for the CVV number.

To use, just specify a property in this way:
```
{
  [...],
  "properties": {
    "cvv": {
      "type": "string",
      "format": "cvv"
    }
  },
  [...]
}
```