### PR TITLE
[WIP] Update test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
             "type": "package",
             "package": {
                 "name": "json-schema/JSON-Schema-Test-Suite",
-                "version": "1.2.0",
+                "version": "dev-master",
                 "source": {
                     "url": "https://github.com/json-schema/JSON-Schema-Test-Suite",
                     "type": "git",
-                    "reference": "1.2.0"
+                    "reference": "71843cbbd4be3194ee83253b402656550c8c0522"
                 }
             }
         }
@@ -42,7 +42,7 @@
         "phpunit/phpunit" : "^4.8.35",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "~2.3",
-        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
+        "json-schema/JSON-Schema-Test-Suite": "dev-master@dev",
         "league/json-reference": "^1.1.0",
         "ext-curl": "*",
         "peterpostmann/fileuri": "^1.0"

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -21,6 +21,13 @@ class ValidatorTest extends TestCase
 {
     const TEST_SUITE_PATH = __DIR__ . '/../vendor/json-schema/JSON-Schema-Test-Suite/tests';
 
+    const SKIPPED_TESTS = [
+        // // PHP cannot differentiate between large integers and strings.
+        'a bignum is not a string',
+        // see https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/119
+        'ECMA 262 has no support for \\Z anchor from .NET',
+    ];
+
     public function allDraft4Tests()
     {
         $required = glob(self::TEST_SUITE_PATH . '/draft4/*.json');
@@ -85,8 +92,7 @@ class ValidatorTest extends TestCase
                 $validator = new Validator($test->data, $schema);
                 $msg       = $description . ' : ' . $test->description;
 
-                if ($test->description === 'a bignum is not a string') {
-                    // PHP cannot differentiate between large integers and strings.
+                if (in_array($test->description, self::SKIPPED_TESTS)) {
                     continue;
                 }
 


### PR DESCRIPTION
WIP.  Updating the test suite introduced a few failing tests.

- [ ] Recursive references between schemas

This test is not failing because it's recursive but because it requires the dereferencer to walk the current document before attempting to load it via the URI.  See https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/217 and https://github.com/json-schema-org/json-schema-spec/issues/576.

- [ ] a valid tel URI

This is failing because we are using `FILTER_VALIDATE_URL` and it's a URI, not a URL.  I probably need to pull in league/uri-parser but that will bump the minimum version to 7.0.  I was considering doing that anyway.

- [ ] ECMA 262 regex non-compliance

This is failing because we use php's PCRE regex instead of ECMA.  I don't think it's worth trying to fix this, it's an optional test.